### PR TITLE
Enable prescribed ice for UFS

### DIFF
--- a/cicecore/drivers/nuopc/cmeps/CICE_RunMod.F90
+++ b/cicecore/drivers/nuopc/cmeps/CICE_RunMod.F90
@@ -191,14 +191,12 @@
          call init_history_bgc
          call ice_timer_stop(timer_diags)   ! diagnostics/history
 
-#ifdef CESMCOUPLED
          if (prescribed_ice) then  ! read prescribed ice
             call t_barrierf('cice_run_presc_BARRIER',MPI_COMM_ICE)
             call t_startf ('cice_run_presc')
             call ice_prescribed_run(idate, msec)
             call t_stopf ('cice_run_presc')
          endif
-#endif
 
          call step_prep
 

--- a/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
@@ -885,7 +885,7 @@ contains
     ! Prescribed ice initialization
     !-----------------------------------------------------------------
 
-    call ice_prescribed_init(clock, ice_mesh, rc)
+    call ice_prescribed_init(gcomp, clock, ice_mesh, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
 #ifdef CESMCOUPLED

--- a/cicecore/drivers/nuopc/cmeps/ice_prescribed_mod.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_prescribed_mod.F90
@@ -7,33 +7,15 @@ module ice_prescribed_mod
   ! Ice/ocean fluxes are set to zero, and ice dynamics are not calculated.
   ! Regridding and data cycling capabilities are included.
 
-  use ESMF, only : ESMF_Clock, ESMF_Mesh, ESMF_SUCCESS, ESMF_FAILURE
+  use ESMF, only : ESMF_GridComp, ESMF_Clock, ESMF_Mesh, ESMF_SUCCESS, ESMF_FAILURE
   use ESMF, only : ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU, ESMF_Finalize, ESMF_END_ABORT
-
-#ifndef CESMCOUPLED
-
-  use ice_kinds_mod
-  implicit none
-  private ! except
-  public  :: ice_prescribed_init      ! initialize input data stream
-  logical(kind=log_kind), parameter, public :: prescribed_ice = .false.     ! true if prescribed ice
-contains
-  ! This is a stub routine for now
-  subroutine ice_prescribed_init(clock, mesh, rc)
-    type(ESMF_Clock)       , intent(in)  :: clock
-    type(ESMF_Mesh)        , intent(in)  :: mesh
-    integer                , intent(out) :: rc
-    ! do nothing
-    rc = ESMF_SUCCESS
-  end subroutine ice_prescribed_init
-
-#else
 
   use ice_kinds_mod
   use shr_nl_mod       , only : shr_nl_find_group_name
   use dshr_strdata_mod , only : shr_strdata_type, shr_strdata_print
   use dshr_strdata_mod , only : shr_strdata_init_from_inline, shr_strdata_advance
   use dshr_methods_mod , only : dshr_fldbun_getfldptr
+  use dshr_mod         , only : dshr_pio_init
   use ice_broadcast
   use ice_communicate   , only : my_task, master_task, MPI_COMM_ICE
   use ice_fileunits
@@ -43,7 +25,7 @@ contains
   use ice_blocks        , only : nx_block, ny_block, block, get_block
   use ice_domain        , only : nblocks, distrb_info, blocks_ice
   use ice_grid          , only : TLAT, TLON, hm, tmask, tarea, grid_type, ocn_gridcell_frac
-  use ice_calendar      , only : idate, calendar_type
+  use ice_calendar      , only : idate, msec, calendar_type
   use ice_arrays_column , only : hin_max
   use ice_read_write
   use ice_exit          , only: abort_ice
@@ -74,13 +56,17 @@ contains
 contains
 !===============================================================================
 
-  subroutine ice_prescribed_init(clock, mesh, rc)
+  subroutine ice_prescribed_init(gcomp, clock, mesh, rc)
 
     ! Prescribed ice initialization
 
-    include 'mpif.h'
+#ifndef SERIAL_REMOVE_MPI
+    !TODO: add 1d character array to cicecore/cicedyn/infrastructure/comm/mpi/ice_broadcast.F90
+    use mpi   ! MPI Fortran module
+#endif
 
     ! input/output parameters
+    type(ESMF_GridComp)    , intent(in)  :: gcomp
     type(ESMF_Clock)       , intent(in)  :: clock
     type(ESMF_Mesh)        , intent(in)  :: mesh
     integer                , intent(out) :: rc
@@ -93,6 +79,7 @@ contains
     character(len=char_len_long)     :: stream_dataFiles(nFilesMaximum)
     character(len=char_len_long)     :: stream_varname
     character(len=char_len_long)     :: stream_mapalgo
+    character(len=char_len_long)     :: stream_taxmode
     integer(kind=int_kind)           :: stream_yearfirst   ! first year in stream to use
     integer(kind=int_kind)           :: stream_yearlast    ! last year in stream to use
     integer(kind=int_kind)           :: stream_yearalign   ! align stream_year_first
@@ -110,6 +97,7 @@ contains
          stream_varname ,               &
          stream_datafiles,              &
          stream_mapalgo,                &
+         stream_taxmode,                &
          stream_yearalign,              &
          stream_yearfirst ,             &
          stream_yearlast
@@ -125,6 +113,7 @@ contains
     stream_meshfile     = ' '
     stream_datafiles(:) = ' '
     stream_mapalgo      = 'bilinear'
+    stream_taxmode      = 'cycle'
 
     ! read namelist on master task
     if (my_task == master_task) then
@@ -155,6 +144,7 @@ contains
        call broadcast_scalar(stream_yearlast  , master_task)
        call broadcast_scalar(stream_meshfile  , master_task)
        call broadcast_scalar(stream_mapalgo   , master_task)
+       call broadcast_scalar(stream_taxmode   , master_task)
        call broadcast_scalar(stream_varname   , master_task)
        call mpi_bcast(stream_dataFiles, len(stream_datafiles(1))*NFilesMaximum, MPI_CHARACTER, 0, MPI_COMM_ICE, ierr)
 
@@ -172,11 +162,17 @@ contains
           write(nu_diag,F00) '  stream_meshfile  = ',trim(stream_meshfile)
           write(nu_diag,F00) '  stream_varname   = ',trim(stream_varname)
           write(nu_diag,F00) '  stream_mapalgo   = ',trim(stream_mapalgo)
+          write(nu_diag,F00) '  stream_taxmode   = ',trim(stream_taxmode)
           do n = 1,nFile
              write(nu_diag,F00) '  stream_datafiles   = ',trim(stream_dataFiles(n))
           end do
           write(nu_diag,*) ' '
        endif
+
+#ifndef CESMCOUPLED
+       !CESM does this elsewhere
+       call dshr_pio_init(gcomp, sdat, nu_diag, rc)
+#endif
 
        ! initialize sdat
        call shr_strdata_init_from_inline(sdat,               &
@@ -189,13 +185,13 @@ contains
             stream_lev_dimname  = 'null',                    &
             stream_mapalgo      = trim(stream_mapalgo),      &
             stream_filenames    = stream_datafiles(1:nfile), &
-            stream_fldlistFile  = (/'ice_cov'/),             &
-            stream_fldListModel = (/'ice_cov'/),             &
+            stream_fldlistFile  = (/trim(stream_varname)/),  &
+            stream_fldListModel = (/trim(stream_varname)/),  &
             stream_yearFirst    = stream_yearFirst,          &
             stream_yearLast     = stream_yearLast,           &
             stream_yearAlign    = stream_yearAlign ,         &
             stream_offset       = 0,                         &
-            stream_taxmode      = 'cycle',                   &
+            stream_taxmode      = trim(stream_taxmode),      &
             stream_dtlimit      = 1.5_dbl_kind,              &
             stream_tintalgo     = 'linear',                  &
             rc                  = rc)
@@ -211,6 +207,11 @@ contains
           hin_max(1) = 999._dbl_kind
        end if
 
+#ifndef CESMCOUPLED
+       ! If need initial cice values for coupling
+       call ice_prescribed_run(idate, msec)
+#endif
+    
     end if  ! end of if prescribed ice mode
 
   end subroutine ice_prescribed_init
@@ -488,7 +489,5 @@ contains
     call init_flux_ocn
 
   end subroutine ice_prescribed_phys
-
-#endif
 
 end module ice_prescribed_mod

--- a/cicecore/drivers/nuopc/cmeps/ice_prescribed_mod.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_prescribed_mod.F90
@@ -6,6 +6,10 @@ module ice_prescribed_mod
   ! prescribed.  Air/ice fluxes are computed to get surface temperature,
   ! Ice/ocean fluxes are set to zero, and ice dynamics are not calculated.
   ! Regridding and data cycling capabilities are included.
+  
+  ! Note (8/8/2024): This code is dependent on CDEPS (to input ice data).
+  ! In the interests of cleaner code, drivers/nuopc/cmeps now is too.
+  ! If problematic, please see https://github.com/CICE-Consortium/CICE/pull/964 for alternatives.
 
   use ESMF, only : ESMF_GridComp, ESMF_Clock, ESMF_Mesh, ESMF_SUCCESS, ESMF_FAILURE
   use ESMF, only : ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU, ESMF_Finalize, ESMF_END_ABORT


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>

## PR checklist
- [x] Short (1 sentence) summary of your PR: 
    Enable prescribed ice CICE for UFS in nuopc/cmeps cap
- [x] Developer(s): 
    Nicholas Szapiro & Denise Worthen
- [ ] Suggest PR reviewers from list in the column to the right.
- [x] Please copy the PR test results link or provide a summary of testing completed below.
   Regression test atm_ds2s_docn_pcice added to ufs-weather-model
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit (when not in prescribed ice)
    - [ ] different at roundoff level
    - [x] more substantial (when in prescribed ice #ifndef cesmcoupled) 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [x] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [x] No 
- [x] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.
Prescribed ice CICE was enclosed by #ifdef CESMCOUPLED in CMEPS driver. This allows use of prescribed ice CICE in ufs-weather-model with CDEPS calls to input (sea ice concentration) from file. Starting as cherry-picked as in UFS